### PR TITLE
Expose Script API: This was as difficult as I expected

### DIFF
--- a/krita_plugin/krita_diff/client.py
+++ b/krita_plugin/krita_diff/client.py
@@ -205,6 +205,7 @@ class Client(QObject):
                     self.ext_cfg.set(key, json.dumps(val))
 
             self.is_connected = True
+            self.status.emit(STATE_READY)
 
         # only get config if there are no pending post requests jamming the backend
         # NOTE: this might prevent get_config() from ever working if zombie requests can happen

--- a/krita_plugin/krita_diff/client.py
+++ b/krita_plugin/krita_diff/client.py
@@ -196,15 +196,18 @@ class Client(QObject):
             self.cfg.set("sd_model_list", obj["sd_models"])
 
             # extension script cfg
-            for ext_type in ("scripts_txt2img", "scripts_img2img"):
+            obj["scripts_inpaint"] = obj["scripts_img2img"]
+            for ext_type in ("scripts_txt2img", "scripts_img2img", "scripts_inpaint"):
                 metadata: Dict[str, List[dict]] = obj[ext_type]
+                self.ext_cfg.set(f"{ext_type}_len", len(metadata))
                 for ext_name, ext_meta in metadata.items():
-                    self.ext_cfg.set(
-                        get_ext_key(ext_type, ext_name), json.dumps(ext_meta)
-                    )
-                    for i, opt in enumerate(ext_meta):
-                        key = get_ext_key(ext_type, ext_name, i)
-                        self.ext_cfg.set(key, opt["val"])
+                    old_val = self.ext_cfg(get_ext_key(ext_type, ext_name))
+                    new_val = json.dumps(ext_meta)
+                    if new_val != old_val:
+                        self.ext_cfg.set(get_ext_key(ext_type, ext_name), new_val)
+                        for i, opt in enumerate(ext_meta):
+                            key = get_ext_key(ext_type, ext_name, i)
+                            self.ext_cfg.set(key, opt["val"])
 
             self.is_connected = True
             self.status.emit(STATE_READY)

--- a/krita_plugin/krita_diff/client.py
+++ b/krita_plugin/krita_diff/client.py
@@ -188,9 +188,9 @@ class Client(QObject):
             self.cfg.set("txt2img_sampler_list", obj["samplers"])
             self.cfg.set("img2img_sampler_list", obj["samplers_img2img"])
             self.cfg.set("inpaint_sampler_list", obj["samplers_img2img"])
-            self.cfg.set("txt2img_script_list", obj["scripts_txt2img"])
-            self.cfg.set("img2img_script_list", obj["scripts_img2img"])
-            self.cfg.set("inpaint_script_list", obj["scripts_img2img"])
+            self.cfg.set("txt2img_script_list", list(obj["scripts_txt2img"].keys()))
+            self.cfg.set("img2img_script_list", list(obj["scripts_img2img"].keys()))
+            self.cfg.set("inpaint_script_list", list(obj["scripts_img2img"].keys()))
             self.cfg.set("face_restorer_model_list", obj["face_restorers"])
             self.cfg.set("sd_model_list", obj["sd_models"])
             self.is_connected = True

--- a/krita_plugin/krita_diff/client.py
+++ b/krita_plugin/krita_diff/client.py
@@ -174,6 +174,8 @@ class Client(QObject):
                 assert len(obj["samplers_img2img"]) > 0
                 assert len(obj["face_restorers"]) > 0
                 assert len(obj["sd_models"]) > 0
+                assert len(obj["scripts_txt2img"]) > 0
+                assert len(obj["scripts_img2img"]) > 0
             except:
                 self.status.emit(
                     f"{STATE_URLERROR}: incompatible response, are you running the right API?"
@@ -186,6 +188,9 @@ class Client(QObject):
             self.cfg.set("txt2img_sampler_list", obj["samplers"])
             self.cfg.set("img2img_sampler_list", obj["samplers_img2img"])
             self.cfg.set("inpaint_sampler_list", obj["samplers_img2img"])
+            self.cfg.set("txt2img_script_list", obj["scripts_txt2img"])
+            self.cfg.set("img2img_script_list", obj["scripts_img2img"])
+            self.cfg.set("inpaint_script_list", obj["scripts_img2img"])
             self.cfg.set("face_restorer_model_list", obj["face_restorers"])
             self.cfg.set("sd_model_list", obj["sd_models"])
             self.is_connected = True
@@ -222,6 +227,7 @@ class Client(QObject):
                 seed=seed,
                 highres_fix=self.cfg("txt2img_highres", bool),
                 denoising_strength=self.cfg("txt2img_denoising_strength", float),
+                script=self.cfg("txt2img_script", str),
             )
 
         self.post("/txt2img", params, cb)
@@ -245,6 +251,7 @@ class Client(QObject):
                 cfg_scale=self.cfg("img2img_cfg_scale", float),
                 denoising_strength=self.cfg("img2img_denoising_strength", float),
                 color_correct=self.cfg("img2img_color_correct", bool),
+                script=self.cfg("img2img_script", str),
                 seed=seed,
             )
 

--- a/krita_plugin/krita_diff/client.py
+++ b/krita_plugin/krita_diff/client.py
@@ -16,7 +16,7 @@ from .defaults import (
     STATE_URLERROR,
     THREADED,
 )
-from .utils import fix_prompt, get_ext_key, img_to_b64
+from .utils import fix_prompt, get_ext_args, get_ext_key, img_to_b64
 
 # NOTE: backend queues up responses, so no explicit need to block multiple requests
 # except to prevent user from spamming themselves
@@ -234,6 +234,8 @@ class Client(QObject):
                 if not self.cfg("txt2img_seed", str).strip() == ""
                 else -1
             )
+            ext_name = self.cfg("txt2img_script", str)
+            ext_args = get_ext_args(self.ext_cfg, "scripts_txt2img", ext_name)
             params.update(self.get_common_params(has_selection))
             params.update(
                 prompt=fix_prompt(self.cfg("txt2img_prompt", str)),
@@ -244,7 +246,8 @@ class Client(QObject):
                 seed=seed,
                 highres_fix=self.cfg("txt2img_highres", bool),
                 denoising_strength=self.cfg("txt2img_denoising_strength", float),
-                script=self.cfg("txt2img_script", str),
+                script=ext_name,
+                script_args=ext_args,
             )
 
         self.post("/txt2img", params, cb)
@@ -259,6 +262,8 @@ class Client(QObject):
                 if not self.cfg("img2img_seed", str).strip() == ""
                 else -1
             )
+            ext_name = self.cfg("img2img_script", str)
+            ext_args = get_ext_args(self.ext_cfg, "scripts_img2img", ext_name)
             params.update(self.get_common_params(has_selection))
             params.update(
                 prompt=fix_prompt(self.cfg("img2img_prompt", str)),
@@ -268,7 +273,8 @@ class Client(QObject):
                 cfg_scale=self.cfg("img2img_cfg_scale", float),
                 denoising_strength=self.cfg("img2img_denoising_strength", float),
                 color_correct=self.cfg("img2img_color_correct", bool),
-                script=self.cfg("img2img_script", str),
+                script=ext_name,
+                script_args=ext_args,
                 seed=seed,
             )
 
@@ -287,6 +293,8 @@ class Client(QObject):
             fill = self.cfg("inpaint_fill_list", "QStringList").index(
                 self.cfg("inpaint_fill", str)
             )
+            ext_name = self.cfg("inpaint_script", str)
+            ext_args = get_ext_args(self.ext_cfg, "scripts_inpaint", ext_name)
             params.update(self.get_common_params(has_selection))
             params.update(
                 prompt=fix_prompt(self.cfg("inpaint_prompt", str)),
@@ -296,6 +304,8 @@ class Client(QObject):
                 cfg_scale=self.cfg("inpaint_cfg_scale", float),
                 denoising_strength=self.cfg("inpaint_denoising_strength", float),
                 color_correct=self.cfg("inpaint_color_correct", bool),
+                script=ext_name,
+                script_args=ext_args,
                 seed=seed,
                 invert_mask=self.cfg("inpaint_invert_mask", bool),
                 mask_blur=self.cfg("inpaint_mask_blur", int),

--- a/krita_plugin/krita_diff/client.py
+++ b/krita_plugin/krita_diff/client.py
@@ -16,7 +16,7 @@ from .defaults import (
     STATE_URLERROR,
     THREADED,
 )
-from .utils import fix_name, fix_prompt, img_to_b64
+from .utils import fix_prompt, get_ext_key, img_to_b64
 
 # NOTE: backend queues up responses, so no explicit need to block multiple requests
 # except to prevent user from spamming themselves
@@ -196,13 +196,12 @@ class Client(QObject):
             self.cfg.set("sd_model_list", obj["sd_models"])
 
             # extension script cfg
-            for script_type in ("scripts_txt2img", "scripts_img2img"):
-                metadata: Dict[str, List[dict]] = obj[script_type]
-                self.ext_cfg.set(script_type, json.dumps(metadata))
-                for script_name, script_meta in metadata.items():
-                    key = "_".join([script_type, fix_name(script_name)])
-                    val = [o["val"] for o in script_meta]
-                    self.ext_cfg.set(key, json.dumps(val))
+            for ext_type in ("scripts_txt2img", "scripts_img2img"):
+                metadata: Dict[str, List[dict]] = obj[ext_type]
+                for ext_name, ext_meta in metadata.items():
+                    for i, opt in enumerate(ext_meta):
+                        key = get_ext_key(ext_type, ext_name, i)
+                        self.ext_cfg.set(key, json.dumps(opt))
 
             self.is_connected = True
             self.status.emit(STATE_READY)

--- a/krita_plugin/krita_diff/client.py
+++ b/krita_plugin/krita_diff/client.py
@@ -199,9 +199,12 @@ class Client(QObject):
             for ext_type in ("scripts_txt2img", "scripts_img2img"):
                 metadata: Dict[str, List[dict]] = obj[ext_type]
                 for ext_name, ext_meta in metadata.items():
+                    self.ext_cfg.set(
+                        get_ext_key(ext_type, ext_name), json.dumps(ext_meta)
+                    )
                     for i, opt in enumerate(ext_meta):
                         key = get_ext_key(ext_type, ext_name, i)
-                        self.ext_cfg.set(key, json.dumps(opt))
+                        self.ext_cfg.set(key, opt["val"])
 
             self.is_connected = True
             self.status.emit(STATE_READY)

--- a/krita_plugin/krita_diff/config.py
+++ b/krita_plugin/krita_diff/config.py
@@ -14,6 +14,8 @@ class Config(QObject):
         correctly such that it should be theoretically possible to have multiple
         instances (maybe multiple dockers controlling multiple remotes?)
 
+        If model is None, Config will not check if keys exist.
+
         Args:
             folder (str, optional): Which folder to store settings in. Defaults to CFG_FOLDER.
             name (str, optional): Name of settings file. Defaults to CFG_NAME.
@@ -46,9 +48,10 @@ class Config(QObject):
         self.lock.lockForRead()
         try:
             # notably QSettings assume strings too unless specified
-            assert self.config.contains(key) and hasattr(
-                self.model, key
-            ), ERR_MISSING_CONFIG
+            if self.model is not None:
+                assert self.config.contains(key) and hasattr(
+                    self.model, key
+                ), ERR_MISSING_CONFIG
             val = self.config.value(key, type=type)
             return val
         finally:
@@ -64,7 +67,8 @@ class Config(QObject):
         """
         self.lock.lockForWrite()
         try:
-            assert hasattr(self.model, key), ERR_MISSING_CONFIG
+            if self.model is not None:
+                assert hasattr(self.model, key), ERR_MISSING_CONFIG
             if overwrite or not self.config.contains(key):
                 self.config.setValue(key, val)
         finally:
@@ -76,6 +80,8 @@ class Config(QObject):
         Args:
             overwrite (bool, optional): Whether to overwrite existing settings, else add only new ones. Defaults to True.
         """
+        if self.model is None:
+            return
         defaults = asdict(self.model)
         for k, v in defaults.items():
             self.set(k, v, overwrite)

--- a/krita_plugin/krita_diff/defaults.py
+++ b/krita_plugin/krita_diff/defaults.py
@@ -21,6 +21,7 @@ POST_TIMEOUT = None  # post might take "forever" depending on batch size/count
 REFRESH_INTERVAL = 3000  # 3 seconds between auto-config refresh
 CFG_FOLDER = "krita"  # which folder in ~/.config to store config
 CFG_NAME = "krita_diff_plugin"  # name of config file
+EXT_CFG_NAME = "krita_diff_plugin_scripts"  # name of config file
 # selection mask can only be added after image is added, so timeout is needed
 ADD_MASK_TIMEOUT = 200
 THREADED = True

--- a/krita_plugin/krita_diff/defaults.py
+++ b/krita_plugin/krita_diff/defaults.py
@@ -16,9 +16,9 @@ STATE_INPAINT = "inpaint done!"
 STATE_UPSCALE = "upscale done!"
 
 # Other currently hardcoded stuff
-GET_CONFIG_TIMEOUT = 2  # 2 second timeout as getting config should be near instant
-POST_TIMEOUT = None  # post might take forever depending on batch size/count
-REFRESH_INTERVAL = 1000  # 4 seconds between auto-config refresh
+GET_CONFIG_TIMEOUT = 4  # there is prevention for get request accumulation
+POST_TIMEOUT = None  # post might take "forever" depending on batch size/count
+REFRESH_INTERVAL = 3000  # 3 seconds between auto-config refresh
 CFG_FOLDER = "krita"  # which folder in ~/.config to store config
 CFG_NAME = "krita_diff_plugin"  # name of config file
 # selection mask can only be added after image is added, so timeout is needed
@@ -67,6 +67,8 @@ class Defaults:
     txt2img_denoising_strength: float = 0.7
     txt2img_seed: str = ""
     txt2img_highres: bool = False
+    txt2img_script: str = "None"
+    txt2img_script_list: List[str] = field(default_factory=lambda: [ERROR_MSG])
     # TODO: Seed variation
 
     img2img_prompt: str = ""
@@ -78,6 +80,8 @@ class Defaults:
     img2img_denoising_strength: float = 0.8
     img2img_seed: str = ""
     img2img_color_correct: bool = False
+    img2img_script: str = "None"
+    img2img_script_list: List[str] = field(default_factory=lambda: [ERROR_MSG])
 
     inpaint_prompt: str = ""
     inpaint_negative_prompt: str = ""
@@ -97,6 +101,8 @@ class Defaults:
     inpaint_full_res: bool = False
     inpaint_full_res_padding: int = 32
     inpaint_color_correct: bool = True
+    inpaint_script: str = "None"
+    inpaint_script_list: List[str] = field(default_factory=lambda: [ERROR_MSG])
 
     upscale_upscaler_name: str = "None"
     upscale_downscale_first: bool = False

--- a/krita_plugin/krita_diff/defaults.py
+++ b/krita_plugin/krita_diff/defaults.py
@@ -16,7 +16,7 @@ STATE_INPAINT = "inpaint done!"
 STATE_UPSCALE = "upscale done!"
 
 # Other currently hardcoded stuff
-GET_CONFIG_TIMEOUT = 4  # there is prevention for get request accumulation
+GET_CONFIG_TIMEOUT = 10  # there is prevention for get request accumulation
 POST_TIMEOUT = None  # post might take "forever" depending on batch size/count
 REFRESH_INTERVAL = 3000  # 3 seconds between auto-config refresh
 CFG_FOLDER = "krita"  # which folder in ~/.config to store config

--- a/krita_plugin/krita_diff/docker.py
+++ b/krita_plugin/krita_diff/docker.py
@@ -2,7 +2,7 @@ from functools import partial
 
 from krita import DockWidget, QScrollArea, QTabWidget, QTimer, QVBoxLayout, QWidget
 
-from .defaults import REFRESH_INTERVAL
+from .defaults import REFRESH_INTERVAL, STATE_INIT, STATE_READY, STATE_URLERROR
 from .pages import (
     ConfigTabWidget,
     Img2ImgTabWidget,
@@ -11,7 +11,7 @@ from .pages import (
     Txt2ImgTabWidget,
     UpscaleTabWidget,
 )
-from .script import STATE_INIT, script
+from .script import script
 from .widgets import QLabel
 
 
@@ -81,6 +81,8 @@ class SDPluginDocker(DockWidget):
         self.tabs.currentChanged.connect(partial(script.cfg.set, "tab_index"))
 
     def update_status_bar(self, s):
+        if s == STATE_READY and STATE_URLERROR not in self.status_bar.text():
+            return
         self.status_bar.setText(f"<b>Status:</b> {s}")
 
     def update_remote_config(self):

--- a/krita_plugin/krita_diff/docker.py
+++ b/krita_plugin/krita_diff/docker.py
@@ -14,6 +14,11 @@ from .pages import (
 from .script import script
 from .widgets import QLabel
 
+# TODO:
+# - Consider making QuickConfig a dropdown to save vertical space
+# - Come up with more ways to save vertical space for inpaint
+# - Save horizontal space too
+
 
 class SDPluginDocker(DockWidget):
     def __init__(self, *args, **kwargs):

--- a/krita_plugin/krita_diff/pages/common.py
+++ b/krita_plugin/krita_diff/pages/common.py
@@ -14,15 +14,15 @@ class SDCommonWidget(QWidget):
 
         # Model list
         self.sd_model_layout = QComboBoxLayout(
-            script, "sd_model_list", "sd_model", label="SD model:", num_chars=20
+            script.cfg, "sd_model_list", "sd_model", label="SD model:", num_chars=20
         )
 
         # batch size & count
         self.batch_count_layout = QSpinBoxLayout(
-            script, "sd_batch_count", label="Batch count:", min=1, max=9999, step=1
+            script.cfg, "sd_batch_count", label="Batch count:", min=1, max=9999, step=1
         )
         self.batch_size_layout = QSpinBoxLayout(
-            script, "sd_batch_size", label="Batch size:", min=1, max=9999, step=1
+            script.cfg, "sd_batch_size", label="Batch size:", min=1, max=9999, step=1
         )
         batch_layout = QHBoxLayout()
         batch_layout.addLayout(self.batch_count_layout)
@@ -30,10 +30,10 @@ class SDCommonWidget(QWidget):
 
         # base/max size adjustment
         self.base_size_layout = QSpinBoxLayout(
-            script, "sd_base_size", label="Base size:", min=64, max=8192, step=64
+            script.cfg, "sd_base_size", label="Base size:", min=64, max=8192, step=64
         )
         self.max_size_layout = QSpinBoxLayout(
-            script, "sd_max_size", label="Max size:", min=64, max=8192, step=64
+            script.cfg, "sd_max_size", label="Max size:", min=64, max=8192, step=64
         )
         size_layout = QHBoxLayout()
         size_layout.addLayout(self.base_size_layout)
@@ -41,18 +41,18 @@ class SDCommonWidget(QWidget):
 
         # global upscaler
         self.upscaler_layout = QComboBoxLayout(
-            script, "upscaler_list", "upscaler_name", label="Upscaler:"
+            script.cfg, "upscaler_list", "upscaler_name", label="Upscaler:"
         )
 
         # Restore faces
         self.face_restorer_layout = QComboBoxLayout(
-            script,
+            script.cfg,
             "face_restorer_model_list",
             "face_restorer_model",
             label="Face restorer:",
         )
         self.codeformer_weight_layout = QSpinBoxLayout(
-            script,
+            script.cfg,
             "codeformer_weight",
             label="CodeFormer weight (max 0, min 1):",
             step=0.01,

--- a/krita_plugin/krita_diff/pages/common.py
+++ b/krita_plugin/krita_diff/pages/common.py
@@ -1,9 +1,7 @@
-from functools import partial
-
-from krita import QCheckBox, QHBoxLayout, QVBoxLayout, QWidget
+from krita import QHBoxLayout, QVBoxLayout, QWidget
 
 from ..script import script
-from ..widgets import QComboBoxLayout, QLabel, QSpinBoxLayout
+from ..widgets import QCheckBox, QComboBoxLayout, QLabel, QSpinBoxLayout
 
 
 class SDCommonWidget(QWidget):
@@ -59,7 +57,7 @@ class SDCommonWidget(QWidget):
         )
 
         # Tiling mode
-        self.tiling = QCheckBox("Tiling mode")
+        self.tiling = QCheckBox(script.cfg, "sd_tiling", "Tiling mode")
 
         layout = QVBoxLayout()
         layout.addWidget(title)
@@ -82,7 +80,7 @@ class SDCommonWidget(QWidget):
         self.upscaler_layout.cfg_init()
         self.face_restorer_layout.cfg_init()
         self.codeformer_weight_layout.cfg_init()
-        self.tiling.setChecked(script.cfg("sd_tiling", bool))
+        self.tiling.cfg_init()
 
     def cfg_connect(self):
         self.sd_model_layout.cfg_connect()
@@ -92,8 +90,8 @@ class SDCommonWidget(QWidget):
         self.max_size_layout.cfg_connect()
         self.upscaler_layout.cfg_connect()
         self.face_restorer_layout.cfg_connect()
-        self.codeformer_weight_layout.cfg_init()
-        self.tiling.toggled.connect(partial(script.cfg.set, "sd_tiling"))
+        self.codeformer_weight_layout.cfg_connect()
+        self.tiling.cfg_connect()
 
         # Hide codeformer_weight when model isnt codeformer
         def toggle_codeformer_weights(visible):

--- a/krita_plugin/krita_diff/pages/config.py
+++ b/krita_plugin/krita_diff/pages/config.py
@@ -1,10 +1,10 @@
 from functools import partial
 
-from krita import QCheckBox, QHBoxLayout, QLineEdit, QPushButton, QVBoxLayout, QWidget
+from krita import QHBoxLayout, QLineEdit, QPushButton, QVBoxLayout, QWidget
 
-from ..defaults import DEFAULTS, STATE_READY
+from ..defaults import DEFAULTS
 from ..script import script
-from ..widgets import QLabel
+from ..widgets import QCheckBox, QLabel
 
 
 class ConfigTabWidget(QWidget):
@@ -22,24 +22,42 @@ class ConfigTabWidget(QWidget):
 
         # Plugin settings
         self.just_use_yaml = QCheckBox(
-            "Override with krita_config.yaml (unrecommended)"
+            script.cfg,
+            "just_use_yaml",
+            "Override with krita_config.yaml (unrecommended)",
         )
-        self.create_mask_layer = QCheckBox("Create transparency mask from selection")
-        self.save_temp_images = QCheckBox("Save images sent to/from backend for debug")
-        self.fix_aspect_ratio = QCheckBox("Fix aspect ratio for selections")
-        self.only_full_img_tiling = QCheckBox("Only allow tiling with no selection")
-        self.include_grid = QCheckBox("Include grid for txt2img and img2img")
+        self.create_mask_layer = QCheckBox(
+            script.cfg, "create_mask_layer", "Create transparency mask from selection"
+        )
+        self.save_temp_images = QCheckBox(
+            script.cfg, "save_temp_images", "Save images sent to/from backend for debug"
+        )
+        self.fix_aspect_ratio = QCheckBox(
+            script.cfg, "fix_aspect_ratio", "Fix aspect ratio for selections"
+        )
+        self.only_full_img_tiling = QCheckBox(
+            script.cfg, "only_full_img_tiling", "Only allow tiling with no selection"
+        )
+        self.include_grid = QCheckBox(
+            script.cfg, "include_grid", "Include grid for txt2img and img2img"
+        )
 
         # webUI/backend settings
-        self.filter_nsfw = QCheckBox("Filter NSFW content")
+        self.filter_nsfw = QCheckBox(script.cfg, "filter_nsfw", "Filter NSFW content")
         self.img2img_color_correct = QCheckBox(
-            "Color correct img2img for better blending"
+            script.cfg,
+            "img2img_color_correct",
+            "Color correct img2img for better blending",
         )
         self.inpaint_color_correct = QCheckBox(
-            "Color correct inpaint for better blending"
+            script.cfg,
+            "inpaint_color_correct",
+            "Color correct inpaint for better blending",
         )
         self.do_exact_steps = QCheckBox(
-            "Don't decrease steps based on denoising strength"
+            script.cfg,
+            "do_exact_steps",
+            "Don't decrease steps based on denoising strength",
         )
 
         self.refresh_btn = QPushButton("Auto-Refresh Options Now")
@@ -89,16 +107,16 @@ class ConfigTabWidget(QWidget):
         if self.base_url.text() != base_url:
             self.base_url.setText(base_url)
 
-        self.just_use_yaml.setChecked(script.cfg("just_use_yaml", bool))
-        self.create_mask_layer.setChecked(script.cfg("create_mask_layer", bool))
-        self.save_temp_images.setChecked(script.cfg("save_temp_images", bool))
-        self.fix_aspect_ratio.setChecked(script.cfg("fix_aspect_ratio", bool))
-        self.only_full_img_tiling.setChecked(script.cfg("only_full_img_tiling", bool))
-        self.include_grid.setChecked(script.cfg("include_grid", bool))
-        self.filter_nsfw.setChecked(script.cfg("filter_nsfw", bool))
-        self.img2img_color_correct.setChecked(script.cfg("img2img_color_correct", bool))
-        self.inpaint_color_correct.setChecked(script.cfg("inpaint_color_correct", bool))
-        self.do_exact_steps.setChecked(script.cfg("do_exact_steps", bool))
+        self.just_use_yaml.cfg_init()
+        self.create_mask_layer.cfg_init()
+        self.save_temp_images.cfg_init()
+        self.fix_aspect_ratio.cfg_init()
+        self.only_full_img_tiling.cfg_init()
+        self.include_grid.cfg_init()
+        self.filter_nsfw.cfg_init()
+        self.img2img_color_correct.cfg_init()
+        self.inpaint_color_correct.cfg_init()
+        self.do_exact_steps.cfg_init()
 
     def cfg_connect(self):
         self.base_url.textChanged.connect(partial(script.cfg.set, "base_url"))
@@ -107,28 +125,16 @@ class ConfigTabWidget(QWidget):
         self.base_url_reset.released.connect(
             lambda: self.base_url.setText(DEFAULTS.base_url)
         )
-        self.just_use_yaml.toggled.connect(partial(script.cfg.set, "just_use_yaml"))
-        self.create_mask_layer.toggled.connect(
-            partial(script.cfg.set, "create_mask_layer")
-        )
-        self.save_temp_images.toggled.connect(
-            partial(script.cfg.set, "save_temp_images")
-        )
-        self.fix_aspect_ratio.toggled.connect(
-            partial(script.cfg.set, "fix_aspect_ratio")
-        )
-        self.only_full_img_tiling.toggled.connect(
-            partial(script.cfg.set, "only_full_img_tiling")
-        )
-        self.include_grid.toggled.connect(partial(script.cfg.set, "include_grid"))
-        self.filter_nsfw.toggled.connect(partial(script.cfg.set, "filter_nsfw"))
-        self.img2img_color_correct.toggled.connect(
-            partial(script.cfg.set, "img2img_color_correct")
-        )
-        self.inpaint_color_correct.toggled.connect(
-            partial(script.cfg.set, "inpaint_color_correct")
-        )
-        self.do_exact_steps.toggled.connect(partial(script.cfg.set, "do_exact_steps"))
+        self.just_use_yaml.cfg_connect()
+        self.create_mask_layer.cfg_connect()
+        self.save_temp_images.cfg_connect()
+        self.fix_aspect_ratio.cfg_connect()
+        self.only_full_img_tiling.cfg_connect()
+        self.include_grid.cfg_connect()
+        self.filter_nsfw.cfg_connect()
+        self.img2img_color_correct.cfg_connect()
+        self.inpaint_color_correct.cfg_connect()
+        self.do_exact_steps.cfg_connect()
 
         def update_remote_config():
             script.update_config()

--- a/krita_plugin/krita_diff/pages/extension.py
+++ b/krita_plugin/krita_diff/pages/extension.py
@@ -15,18 +15,17 @@ from ..widgets import (
     QSpinBoxLayout,
 )
 
-# TODO:
-# - NOTE: backend will send empty scripts followed by the real one, have to detect
-#   for that
-# - Consider making QuickConfig a dropdown to save vertical space
-# - Come up with more ways to save vertical space for inpaint
-# - Save horizontal space too
 
 # TODO: dynamically adjust script options available without needing to restart plugin
-
-
 class ExtWidget(QWidget):
     def __init__(self, ext_cfg: Config, ext_type: str, ext_name: str, *args, **kwargs):
+        """Dynamically create form for script based on metadata.
+
+        Args:
+            ext_cfg (Config): Config object to get metadata from.
+            ext_type (str): Whether metadata is in "scripts_txt2img", "scripts_img2img" or "scripts_inpaint"
+            ext_name (str): Name of script.
+        """
         super(ExtWidget, self).__init__(*args, **kwargs)
 
         get_key = partial(get_ext_key, ext_type, ext_name)
@@ -76,6 +75,8 @@ class ExtSectionLayout(QVBoxLayout):
     def __init__(self, cfg_prefix: str, *args, **kwargs):
         super(ExtSectionLayout, self).__init__(*args, **kwargs)
 
+        # NOTE: backend will send empty scripts followed by the real one, have to
+        # detect for that
         self.is_init = False
 
         self.dropdown = QComboBoxLayout(
@@ -92,6 +93,7 @@ class ExtSectionLayout(QVBoxLayout):
         self.init_ui_once_if_ready()
 
     def init_ui_once_if_ready(self):
+        """Init UI only once, and only when its ready (aka metadata is present)."""
         if self.is_init:
             return
         if len(self.ext_names()) != script.ext_cfg(f"{self.ext_type}_len", int):

--- a/krita_plugin/krita_diff/pages/extension.py
+++ b/krita_plugin/krita_diff/pages/extension.py
@@ -6,7 +6,6 @@ from krita import QVBoxLayout, QWidget
 from ..script import Script
 
 # TODO:
-# - modify all widgets (that can) to use Config directly instead of Script
 # - ExtLayout that given options: List[dict] creates the respective widgets
 #   and links them to the ext_cfg
 # - The combobox for selecting the script should be moved to ExtWidget
@@ -14,6 +13,9 @@ from ..script import Script
 # - ExtWidget initializes only once i.e. when the scripts are loaded
 # - NOTE: backend will send empty scripts followed by the real one, have to detect
 #   for that
+# - Consider making QuickConfig a dropdown to save vertical space
+# - Come up with more ways to save vertical space for inpaint
+# - Save horizontal space too
 
 
 class ExtWidget(QWidget):

--- a/krita_plugin/krita_diff/pages/extension.py
+++ b/krita_plugin/krita_diff/pages/extension.py
@@ -1,0 +1,44 @@
+import json
+from typing import Any, Dict, List
+
+from krita import QVBoxLayout, QWidget
+
+from ..script import Script
+
+# TODO:
+# - modify all widgets (that can) to use Config directly instead of Script
+# - ExtLayout that given options: List[dict] creates the respective widgets
+#   and links them to the ext_cfg
+# - The combobox for selecting the script should be moved to ExtWidget
+# - ExtWidget now manages ExtLayout for each script and their visibility
+# - ExtWidget initializes only once i.e. when the scripts are loaded
+# - NOTE: backend will send empty scripts followed by the real one, have to detect
+#   for that
+
+
+class ExtWidget(QWidget):
+    def __init__(self, script: Script, key: str, *args, **kwargs):
+        super(ExtWidget, self).__init__(*args, **kwargs)
+        self.script = script
+        self.cfg_key = key
+        self.is_init = False
+
+        meta = self.get_meta()
+        if len(meta) > 1:
+            self.init_ui()
+
+    def get_meta(self) -> Dict[str, List[dict]]:
+        try:
+            return json.loads(self.script.ext_cfg(self.cfg_key))
+        except:
+            return {}
+
+    def init_ui(self):
+        if self.is_init:
+            return
+        self.is_init = True
+
+        for opt in self.get_meta():
+            type = opt["type"]
+            if type == "None":
+                continue

--- a/krita_plugin/krita_diff/pages/img_base.py
+++ b/krita_plugin/krita_diff/pages/img_base.py
@@ -31,8 +31,8 @@ class ImgTabBaseWidget(QWidget):
         )
         self.script_layout = QComboBoxLayout(
             script,
-            f"{cfg_prefix}_script",
             f"{cfg_prefix}_script_list",
+            f"{cfg_prefix}_script",
             label="(TODO) Scripts:",
         )
 
@@ -58,7 +58,7 @@ class ImgTabBaseWidget(QWidget):
         )
 
     def cfg_init(self):
-        # self.script_layout.cfg_init()
+        self.script_layout.cfg_init()
         self.prompt_layout.cfg_init()
         self.seed_layout.cfg_init()
         self.sampler_layout.cfg_init()
@@ -67,7 +67,7 @@ class ImgTabBaseWidget(QWidget):
         self.denoising_strength_layout.cfg_init()
 
     def cfg_connect(self):
-        # self.script_layout.cfg_connect()
+        self.script_layout.cfg_connect()
         self.prompt_layout.cfg_connect()
         self.seed_layout.cfg_connect()
         self.sampler_layout.cfg_connect()

--- a/krita_plugin/krita_diff/pages/img_base.py
+++ b/krita_plugin/krita_diff/pages/img_base.py
@@ -9,28 +9,32 @@ class ImgTabBaseWidget(QWidget):
         super(ImgTabBaseWidget, self).__init__(*args, **kwargs)
 
         self.prompt_layout = QPromptLayout(
-            script, f"{cfg_prefix}_prompt", f"{cfg_prefix}_negative_prompt"
+            script.cfg, f"{cfg_prefix}_prompt", f"{cfg_prefix}_negative_prompt"
         )
 
         self.seed_layout = QLineEditLayout(
-            script, f"{cfg_prefix}_seed", label="Seed:", placeholder="Random"
+            script.cfg, f"{cfg_prefix}_seed", label="Seed:", placeholder="Random"
         )
 
         self.sampler_layout = QComboBoxLayout(
-            script,
+            script.cfg,
             f"{cfg_prefix}_sampler_list",
             f"{cfg_prefix}_sampler",
             label="Sampler:",
         )
 
         self.steps_layout = QSpinBoxLayout(
-            script, f"{cfg_prefix}_steps", label="Steps:", min=1, max=9999, step=1
+            script.cfg, f"{cfg_prefix}_steps", label="Steps:", min=1, max=9999, step=1
         )
         self.cfg_scale_layout = QSpinBoxLayout(
-            script, f"{cfg_prefix}_cfg_scale", label="CFG scale:", min=1.0, max=9999.0
+            script.cfg,
+            f"{cfg_prefix}_cfg_scale",
+            label="CFG scale:",
+            min=1.0,
+            max=9999.0,
         )
         self.script_layout = QComboBoxLayout(
-            script,
+            script.cfg,
             f"{cfg_prefix}_script_list",
             f"{cfg_prefix}_script",
             label="(TODO) Scripts:",
@@ -51,7 +55,7 @@ class ImgTabBaseWidget(QWidget):
 
         # not added so inheritants can place it wherever they want
         self.denoising_strength_layout = QSpinBoxLayout(
-            script,
+            script.cfg,
             f"{cfg_prefix}_denoising_strength",
             label="Denoising strength:",
             step=0.01,

--- a/krita_plugin/krita_diff/pages/img_base.py
+++ b/krita_plugin/krita_diff/pages/img_base.py
@@ -2,10 +2,11 @@ from krita import QHBoxLayout, QVBoxLayout, QWidget
 
 from ..script import script
 from ..widgets import QComboBoxLayout, QLineEditLayout, QPromptLayout, QSpinBoxLayout
+from .extension import ExtSectionLayout
 
 
 class ImgTabBaseWidget(QWidget):
-    def __init__(self, cfg_prefix: str = "", *args, **kwargs):
+    def __init__(self, cfg_prefix: str, *args, **kwargs):
         super(ImgTabBaseWidget, self).__init__(*args, **kwargs)
 
         self.prompt_layout = QPromptLayout(
@@ -33,19 +34,15 @@ class ImgTabBaseWidget(QWidget):
             min=1.0,
             max=9999.0,
         )
-        self.script_layout = QComboBoxLayout(
-            script.cfg,
-            f"{cfg_prefix}_script_list",
-            f"{cfg_prefix}_script",
-            label="(TODO) Scripts:",
-        )
+
+        self.ext_layout = ExtSectionLayout(cfg_prefix)
 
         inline_layout = QHBoxLayout()
         inline_layout.addLayout(self.steps_layout)
         inline_layout.addLayout(self.cfg_scale_layout)
 
         self.layout = layout = QVBoxLayout()
-        layout.addLayout(self.script_layout)
+        layout.addLayout(self.ext_layout)
         layout.addLayout(self.prompt_layout)
         layout.addLayout(self.seed_layout)
         layout.addLayout(self.sampler_layout)
@@ -62,7 +59,7 @@ class ImgTabBaseWidget(QWidget):
         )
 
     def cfg_init(self):
-        self.script_layout.cfg_init()
+        self.ext_layout.cfg_init()
         self.prompt_layout.cfg_init()
         self.seed_layout.cfg_init()
         self.sampler_layout.cfg_init()
@@ -71,7 +68,7 @@ class ImgTabBaseWidget(QWidget):
         self.denoising_strength_layout.cfg_init()
 
     def cfg_connect(self):
-        self.script_layout.cfg_connect()
+        self.ext_layout.cfg_connect()
         self.prompt_layout.cfg_connect()
         self.seed_layout.cfg_connect()
         self.sampler_layout.cfg_connect()

--- a/krita_plugin/krita_diff/pages/inpaint.py
+++ b/krita_plugin/krita_diff/pages/inpaint.py
@@ -14,7 +14,7 @@ class InpaintTabWidget(ImgTabBaseWidget):
 
         self.invert_mask = QCheckBox("Invert mask")
         self.mask_blur_layout = QSpinBoxLayout(
-            script, "inpaint_mask_blur", "Mask blur (px):", min=0, max=9999, step=1
+            script.cfg, "inpaint_mask_blur", "Mask blur (px):", min=0, max=9999, step=1
         )
 
         inline1 = QHBoxLayout()
@@ -22,12 +22,12 @@ class InpaintTabWidget(ImgTabBaseWidget):
         inline1.addLayout(self.mask_blur_layout)
 
         self.fill_layout = QComboBoxLayout(
-            script, "inpaint_fill_list", "inpaint_fill", label="Inpaint fill:"
+            script.cfg, "inpaint_fill_list", "inpaint_fill", label="Inpaint fill:"
         )
 
         self.full_res = QCheckBox("Inpaint full res")
         self.full_res_padding_layout = QSpinBoxLayout(
-            script,
+            script.cfg,
             "inpaint_full_res_padding",
             "Padding (px):",
             min=0,

--- a/krita_plugin/krita_diff/pages/inpaint.py
+++ b/krita_plugin/krita_diff/pages/inpaint.py
@@ -1,9 +1,7 @@
-from functools import partial
-
-from krita import QCheckBox, QHBoxLayout, QPushButton
+from krita import QHBoxLayout, QPushButton
 
 from ..script import script
-from ..widgets import QComboBoxLayout, QLabel, QSpinBoxLayout
+from ..widgets import QCheckBox, QComboBoxLayout, QLabel, QSpinBoxLayout
 from .img_base import ImgTabBaseWidget
 
 
@@ -12,7 +10,7 @@ class InpaintTabWidget(ImgTabBaseWidget):
         super(InpaintTabWidget, self).__init__(cfg_prefix="inpaint", *args, **kwargs)
         self.layout.addLayout(self.denoising_strength_layout)
 
-        self.invert_mask = QCheckBox("Invert mask")
+        self.invert_mask = QCheckBox(script.cfg, "inpaint_invert_mask", "Invert mask")
         self.mask_blur_layout = QSpinBoxLayout(
             script.cfg, "inpaint_mask_blur", "Mask blur (px):", min=0, max=9999, step=1
         )
@@ -25,7 +23,7 @@ class InpaintTabWidget(ImgTabBaseWidget):
             script.cfg, "inpaint_fill_list", "inpaint_fill", label="Inpaint fill:"
         )
 
-        self.full_res = QCheckBox("Inpaint full res")
+        self.full_res = QCheckBox(script.cfg, "inpaint_full_res", "Inpaint full res")
         self.full_res_padding_layout = QSpinBoxLayout(
             script.cfg,
             "inpaint_full_res_padding",
@@ -60,8 +58,8 @@ class InpaintTabWidget(ImgTabBaseWidget):
         self.mask_blur_layout.cfg_init()
         self.fill_layout.cfg_init()
         self.full_res_padding_layout.cfg_init()
-        self.invert_mask.setChecked(script.cfg("inpaint_invert_mask", bool))
-        self.full_res.setChecked(script.cfg("inpaint_full_res", bool))
+        self.invert_mask.cfg_init()
+        self.full_res.cfg_init()
 
     def cfg_connect(self):
         super(InpaintTabWidget, self).cfg_connect()
@@ -69,15 +67,14 @@ class InpaintTabWidget(ImgTabBaseWidget):
         self.fill_layout.cfg_connect()
         self.full_res_padding_layout.cfg_connect()
 
-        self.invert_mask.toggled.connect(partial(script.cfg.set, "inpaint_invert_mask"))
+        self.invert_mask.cfg_connect()
 
         def toggle_fullres(enabled):
-            script.cfg.set("inpaint_full_res", enabled)
-
             # hide/show fullres padding
             self.full_res_padding_layout.qlabel.setVisible(enabled)
             self.full_res_padding_layout.qspin.setVisible(enabled)
 
+        self.full_res.cfg_connect()
         self.full_res.toggled.connect(toggle_fullres)
         toggle_fullres(self.full_res.isChecked())
 

--- a/krita_plugin/krita_diff/pages/txt2img.py
+++ b/krita_plugin/krita_diff/pages/txt2img.py
@@ -1,7 +1,7 @@
-from krita import QCheckBox, QHBoxLayout, QPushButton
+from krita import QHBoxLayout, QPushButton
 
 from ..script import script
-from ..widgets import QLabel
+from ..widgets import QCheckBox, QLabel
 from .img_base import ImgTabBaseWidget
 
 
@@ -9,7 +9,7 @@ class Txt2ImgTabWidget(ImgTabBaseWidget):
     def __init__(self, *args, **kwargs):
         super(Txt2ImgTabWidget, self).__init__(cfg_prefix="txt2img", *args, **kwargs)
 
-        self.highres = QCheckBox("Highres fix")
+        self.highres = QCheckBox(script.cfg, "txt2img_highres", "Highres fix")
 
         inline_layout = QHBoxLayout()
         inline_layout.addWidget(self.highres)
@@ -28,18 +28,17 @@ class Txt2ImgTabWidget(ImgTabBaseWidget):
 
     def cfg_init(self):
         super(Txt2ImgTabWidget, self).cfg_init()
-        self.highres.setChecked(script.cfg("txt2img_highres", bool))
+        self.highres.cfg_init()
 
     def cfg_connect(self):
         super(Txt2ImgTabWidget, self).cfg_connect()
 
         def toggle_highres(enabled):
-            script.cfg.set("txt2img_highres", enabled)
-
             # hide/show denoising strength
             self.denoising_strength_layout.qlabel.setVisible(enabled)
             self.denoising_strength_layout.qspin.setVisible(enabled)
 
+        self.highres.cfg_connect()
         self.highres.toggled.connect(toggle_highres)
         toggle_highres(self.highres.isChecked())
 

--- a/krita_plugin/krita_diff/pages/upscale.py
+++ b/krita_plugin/krita_diff/pages/upscale.py
@@ -1,9 +1,7 @@
-from functools import partial
-
-from krita import QCheckBox, QPushButton, QVBoxLayout, QWidget
+from krita import QPushButton, QVBoxLayout, QWidget
 
 from ..script import script
-from ..widgets import QComboBoxLayout, QLabel
+from ..widgets import QCheckBox, QComboBoxLayout, QLabel
 
 
 # TODO: Become SD Upscale tab.
@@ -15,7 +13,11 @@ class UpscaleTabWidget(QWidget):
             script.cfg, "upscaler_list", "upscale_upscaler_name", label="Upscaler:"
         )
 
-        self.downscale_first = QCheckBox("Downscale image x0.5 before upscaling")
+        self.downscale_first = QCheckBox(
+            script.cfg,
+            "upscale_downscale_first",
+            "Downscale image x0.5 before upscaling",
+        )
 
         note = QLabel(
             """
@@ -40,11 +42,9 @@ NOTE:<br/>
 
     def cfg_init(self):
         self.upscaler_layout.cfg_init()
-        self.downscale_first.setChecked(script.cfg("upscale_downscale_first", bool))
+        self.downscale_first.cfg_init()
 
     def cfg_connect(self):
         self.upscaler_layout.cfg_connect()
-        self.downscale_first.toggled.connect(
-            partial(script.cfg.set, "upscale_downscale_first")
-        )
+        self.downscale_first.cfg_connect()
         self.btn.released.connect(lambda: script.action_simple_upscale())

--- a/krita_plugin/krita_diff/pages/upscale.py
+++ b/krita_plugin/krita_diff/pages/upscale.py
@@ -12,7 +12,7 @@ class UpscaleTabWidget(QWidget):
         super(UpscaleTabWidget, self).__init__(*args, **kwargs)
 
         self.upscaler_layout = QComboBoxLayout(
-            script, "upscaler_list", "upscale_upscaler_name", label="Upscaler:"
+            script.cfg, "upscaler_list", "upscale_upscaler_name", label="Upscaler:"
         )
 
         self.downscale_first = QCheckBox("Downscale image x0.5 before upscaling")

--- a/krita_plugin/krita_diff/script.py
+++ b/krita_plugin/krita_diff/script.py
@@ -10,13 +10,10 @@ from .defaults import (
     ERR_NO_DOCUMENT,
     EXT_CFG_NAME,
     STATE_IMG2IMG,
-    STATE_INIT,
     STATE_INPAINT,
-    STATE_READY,
     STATE_RESET_DEFAULT,
     STATE_TXT2IMG,
     STATE_UPSCALE,
-    STATE_URLERROR,
     STATE_WAIT,
 )
 from .utils import (
@@ -60,7 +57,7 @@ class Script(QObject):
         # Persistent settings (should reload between Krita sessions)
         self.cfg = Config()
         # used for webUI scripts aka extensions not to be confused with their extensions
-        self.ext_cfg = Config(name=EXT_CFG_NAME, defaults=None)
+        self.ext_cfg = Config(name=EXT_CFG_NAME, model=None)
         self.client = Client(self.cfg, self.ext_cfg)
         self.client.status.connect(self.status_changed.emit)
 

--- a/krita_plugin/krita_diff/script.py
+++ b/krita_plugin/krita_diff/script.py
@@ -8,6 +8,7 @@ from .config import Config
 from .defaults import (
     ADD_MASK_TIMEOUT,
     ERR_NO_DOCUMENT,
+    EXT_CFG_NAME,
     STATE_IMG2IMG,
     STATE_INIT,
     STATE_INPAINT,
@@ -58,7 +59,9 @@ class Script(QObject):
         super(Script, self).__init__()
         # Persistent settings (should reload between Krita sessions)
         self.cfg = Config()
-        self.client = Client(self.cfg)
+        # used for webUI scripts aka extensions not to be confused with their extensions
+        self.ext_cfg = Config(name=EXT_CFG_NAME, defaults=None)
+        self.client = Client(self.cfg, self.ext_cfg)
         self.client.status.connect(self.status_changed.emit)
 
     def restore_defaults(self, if_empty=False):

--- a/krita_plugin/krita_diff/script.py
+++ b/krita_plugin/krita_diff/script.py
@@ -64,6 +64,7 @@ class Script(QObject):
     def restore_defaults(self, if_empty=False):
         """Restore to default config."""
         self.cfg.restore_defaults(not if_empty)
+        self.ext_cfg.config.remove("")
 
         if not if_empty:
             self.status_changed.emit(STATE_RESET_DEFAULT)

--- a/krita_plugin/krita_diff/utils.py
+++ b/krita_plugin/krita_diff/utils.py
@@ -33,13 +33,6 @@ def get_ext_args(ext_cfg: Config, ext_type: str, ext_name: str):
         if issubclass(typ, list):
             typ = "QStringList"
         val = ext_cfg(get_ext_key(ext_type, ext_name, i), typ)
-
-        if o["is_index"]:
-            if typ == "QStringList":
-                val = [o["opts"].index(v) for v in val]
-            else:
-                val = o["opts"].index(val)
-
         args.append(val)
     return args
 

--- a/krita_plugin/krita_diff/utils.py
+++ b/krita_plugin/krita_diff/utils.py
@@ -10,8 +10,9 @@ def fix_prompt(prompt: str):
     return joined if joined != "" else None
 
 
-def fix_name(name: str):
-    return re.sub(r"\W+", "", name)
+def get_ext_key(ext_type: str, ext_name: str, index: int):
+    """Get name of config key where the ext values would be stored."""
+    return "_".join([ext_type, re.sub(r"\W+", "", ext_name.lower()), str(index)])
 
 
 def find_fixed_aspect_ratio(

--- a/krita_plugin/krita_diff/utils.py
+++ b/krita_plugin/krita_diff/utils.py
@@ -10,9 +10,15 @@ def fix_prompt(prompt: str):
     return joined if joined != "" else None
 
 
-def get_ext_key(ext_type: str, ext_name: str, index: int):
+def get_ext_key(ext_type: str, ext_name: str, index: int = None):
     """Get name of config key where the ext values would be stored."""
-    return "_".join([ext_type, re.sub(r"\W+", "", ext_name.lower()), str(index)])
+    return "_".join(
+        [
+            ext_type,
+            re.sub(r"\W+", "", ext_name.lower()),
+            "meta" if index is None else str(index),
+        ]
+    )
 
 
 def find_fixed_aspect_ratio(

--- a/krita_plugin/krita_diff/utils.py
+++ b/krita_plugin/krita_diff/utils.py
@@ -1,3 +1,4 @@
+import re
 from math import ceil
 
 from krita import Document, QBuffer, QByteArray, QImage, QIODevice
@@ -7,6 +8,10 @@ def fix_prompt(prompt: str):
     """Multiline tokens -> comma-separated tokens. Replace empty prompts with None."""
     joined = ", ".join(filter(bool, [x.strip() for x in prompt.splitlines()]))
     return joined if joined != "" else None
+
+
+def fix_name(name: str):
+    return re.sub(r"\W+", "", name)
 
 
 def find_fixed_aspect_ratio(

--- a/krita_plugin/krita_diff/widgets/__init__.py
+++ b/krita_plugin/krita_diff/widgets/__init__.py
@@ -1,3 +1,4 @@
+from .checkbox import QCheckBox
 from .combo_box import QComboBoxLayout
 from .line_edit import QLineEditLayout
 from .misc import QLabel

--- a/krita_plugin/krita_diff/widgets/__init__.py
+++ b/krita_plugin/krita_diff/widgets/__init__.py
@@ -1,4 +1,4 @@
-from .checkbox import QCheckBox
+from .checkbox import QCheckBox, QMultiCheckBoxLayout
 from .combo_box import QComboBoxLayout
 from .line_edit import QLineEditLayout
 from .misc import QLabel

--- a/krita_plugin/krita_diff/widgets/checkbox.py
+++ b/krita_plugin/krita_diff/widgets/checkbox.py
@@ -67,7 +67,7 @@ class QMultiCheckBoxLayout(QVBoxLayout):
             self.row.addWidget(checkbox)
 
         self.addWidget(self.qlabel)
-        self.addWidget(self.row)
+        self.addLayout(self.row)
 
     def cfg_init(self):
         val = set(self.cfg(self.selected_cfg, "QStringList"))

--- a/krita_plugin/krita_diff/widgets/checkbox.py
+++ b/krita_plugin/krita_diff/widgets/checkbox.py
@@ -1,13 +1,15 @@
 from functools import partial
 
 from krita import QCheckBox as _QCheckBox
+from krita import QHBoxLayout, QVBoxLayout
 
 from ..config import Config
+from .misc import QLabel
 
 
 class QCheckBox(_QCheckBox):
     def __init__(self, cfg: Config, field_cfg: str, label: str = None, *args, **kwargs):
-        """Layout for labelled QLineEdit.
+        """QCheckBox compatible with the config system.
 
         Args:
             cfg (Config): Config to connect to.
@@ -25,3 +27,57 @@ class QCheckBox(_QCheckBox):
 
     def cfg_connect(self):
         self.toggled.connect(partial(self.cfg.set, self.field_cfg))
+
+
+# TODO: adjust number of checkboxes based on options without needing restart
+
+
+class QMultiCheckBoxLayout(QVBoxLayout):
+    def __init__(
+        self,
+        cfg: Config,
+        options_cfg: list,
+        selected_cfg: str,
+        label: str = None,
+        *args,
+        **kwargs
+    ):
+        """Layout for labelled multi-select CheckBox.
+
+        Args:
+            cfg (Config): Config to connect to.
+            options_cfg (list): List of options.
+            selected_cfg (str): Config key to read/write selected options to.
+            label (str, optional): Label, uses `selected_cfg` if None. Defaults to None.
+        """
+        super(QMultiCheckBoxLayout, self).__init__(*args, **kwargs)
+
+        self.cfg = cfg
+        self.options_cfg = options_cfg
+        self.selected_cfg = selected_cfg
+
+        self.qlabel = QLabel(self.selected_cfg if label is None else label)
+
+        # TODO: flexbox-like row breaking
+        self.row = QHBoxLayout()
+        self.qcheckboxes = []
+        for opt in self.options_cfg:
+            checkbox = _QCheckBox(opt)
+            self.qcheckboxes.append(checkbox)
+            self.row.addWidget(checkbox)
+
+        self.addWidget(self.qlabel)
+        self.addWidget(self.row)
+
+    def cfg_init(self):
+        val = set(self.cfg(self.selected_cfg, "QStringList"))
+        for box in self.qcheckboxes:
+            box.setChecked(box.text() in val)
+
+    def cfg_connect(self):
+        def update(_):
+            selected = [b.text() for b in self.qcheckboxes if b.isChecked()]
+            self.cfg.set(self.selected_cfg, selected)
+
+        for box in self.qcheckboxes:
+            box.toggled.connect(update)

--- a/krita_plugin/krita_diff/widgets/checkbox.py
+++ b/krita_plugin/krita_diff/widgets/checkbox.py
@@ -1,0 +1,27 @@
+from functools import partial
+
+from krita import QCheckBox as _QCheckBox
+
+from ..config import Config
+
+
+class QCheckBox(_QCheckBox):
+    def __init__(self, cfg: Config, field_cfg: str, label: str = None, *args, **kwargs):
+        """Layout for labelled QLineEdit.
+
+        Args:
+            cfg (Config): Config to connect to.
+            field_cfg (str): Config key to read/write value to.
+            label (str): Label, uses `field_cfg` if None. Defaults to None.
+        """
+        label = field_cfg if label is None else label
+        super(QCheckBox, self).__init__(label, *args, **kwargs)
+
+        self.cfg = cfg
+        self.field_cfg = field_cfg
+
+    def cfg_init(self):
+        self.setChecked(self.cfg(self.field_cfg, bool))
+
+    def cfg_connect(self):
+        self.toggled.connect(partial(self.cfg.set, self.field_cfg))

--- a/krita_plugin/krita_diff/widgets/checkbox.py
+++ b/krita_plugin/krita_diff/widgets/checkbox.py
@@ -30,8 +30,6 @@ class QCheckBox(_QCheckBox):
 
 
 # TODO: adjust number of checkboxes based on options without needing restart
-
-
 class QMultiCheckBoxLayout(QVBoxLayout):
     def __init__(
         self,

--- a/krita_plugin/krita_diff/widgets/combo_box.py
+++ b/krita_plugin/krita_diff/widgets/combo_box.py
@@ -34,6 +34,7 @@ class QComboBoxLayout(QHBoxLayout):
         self.cfg = cfg
         self.options_cfg = options_cfg
         self.selected_cfg = selected_cfg
+        self._items = set()
 
         self.qlabel = QLabel(self.selected_cfg if label is None else label)
         self.qcombo = QComboBox()
@@ -44,11 +45,18 @@ class QComboBoxLayout(QHBoxLayout):
     def cfg_init(self):
         # prevent value from getting wiped
         val = self.cfg(self.selected_cfg, str)
-        self.qcombo.clear()
-        if isinstance(self.options_cfg, str):
-            self.qcombo.addItems(self.cfg(self.options_cfg, "QStringList"))
-        else:
-            self.qcombo.addItems(self.options_cfg)
+        opts = set(
+            self.cfg(self.options_cfg, "QStringList")
+            if isinstance(self.options_cfg, str)
+            else self.options_cfg
+        )
+        # prevent dropdown from closing when cfg_init is called by update
+        if opts != self._items:
+            self._items = opts
+            self.qcombo.clear()
+            self.qcombo.addItems(list(opts))
+
+        # doesn't throw error if val is not in options; good for us
         self.qcombo.setCurrentText(val)
         if self.num_chars is not None:
             self.qcombo.setFixedWidth(

--- a/krita_plugin/krita_diff/widgets/combo_box.py
+++ b/krita_plugin/krita_diff/widgets/combo_box.py
@@ -2,14 +2,14 @@ from functools import partial
 
 from krita import QComboBox, QHBoxLayout
 
-from ..script import Script
+from ..config import Config
 from .misc import QLabel
 
 
 class QComboBoxLayout(QHBoxLayout):
     def __init__(
         self,
-        script: Script,
+        cfg: Config,
         options_cfg: str,
         selected_cfg: str,
         label: str = None,
@@ -30,7 +30,7 @@ class QComboBoxLayout(QHBoxLayout):
         self.num_chars = num_chars
 
         # Used to connect to config stored in script
-        self.script = script
+        self.cfg = cfg
         self.options_cfg = options_cfg
         self.selected_cfg = selected_cfg
 
@@ -42,9 +42,9 @@ class QComboBoxLayout(QHBoxLayout):
 
     def cfg_init(self):
         # prevent value from getting wiped
-        val = self.script.cfg(self.selected_cfg, str)
+        val = self.cfg(self.selected_cfg, str)
         self.qcombo.clear()
-        self.qcombo.addItems(self.script.cfg(self.options_cfg, "QStringList"))
+        self.qcombo.addItems(self.cfg(self.options_cfg, "QStringList"))
         self.qcombo.setCurrentText(val)
         if self.num_chars is not None:
             self.qcombo.setFixedWidth(
@@ -52,6 +52,4 @@ class QComboBoxLayout(QHBoxLayout):
             )
 
     def cfg_connect(self):
-        self.qcombo.currentTextChanged.connect(
-            partial(self.script.cfg.set, self.selected_cfg)
-        )
+        self.qcombo.currentTextChanged.connect(partial(self.cfg.set, self.selected_cfg))

--- a/krita_plugin/krita_diff/widgets/combo_box.py
+++ b/krita_plugin/krita_diff/widgets/combo_box.py
@@ -1,4 +1,5 @@
 from functools import partial
+from typing import Union
 
 from krita import QComboBox, QHBoxLayout
 
@@ -10,7 +11,7 @@ class QComboBoxLayout(QHBoxLayout):
     def __init__(
         self,
         cfg: Config,
-        options_cfg: str,
+        options_cfg: Union[str, list],
         selected_cfg: str,
         label: str = None,
         num_chars: int = None,
@@ -20,8 +21,8 @@ class QComboBoxLayout(QHBoxLayout):
         """Layout for labelled QComboBox.
 
         Args:
-            script (Script): Script to connect to.
-            options_cfg (str): Config key to read available options from.
+            cfg (Config): Config to connect to.
+            options_cfg (Union[str, list]): Config key to read available options from or list of options.
             selected_cfg (str): Config key to read/write selected option to.
             label (str, optional): Label, uses `selected_cfg` if None. Defaults to None.
             num_chars (int, optional): Max length of qcombo in chars. Defaults to None.
@@ -44,7 +45,10 @@ class QComboBoxLayout(QHBoxLayout):
         # prevent value from getting wiped
         val = self.cfg(self.selected_cfg, str)
         self.qcombo.clear()
-        self.qcombo.addItems(self.cfg(self.options_cfg, "QStringList"))
+        if isinstance(self.options_cfg, str):
+            self.qcombo.addItems(self.cfg(self.options_cfg, "QStringList"))
+        else:
+            self.qcombo.addItems(self.options_cfg)
         self.qcombo.setCurrentText(val)
         if self.num_chars is not None:
             self.qcombo.setFixedWidth(

--- a/krita_plugin/krita_diff/widgets/line_edit.py
+++ b/krita_plugin/krita_diff/widgets/line_edit.py
@@ -2,14 +2,14 @@ from functools import partial
 
 from krita import QHBoxLayout, QLineEdit
 
-from ..script import Script
+from ..config import Config
 from .misc import QLabel
 
 
 class QLineEditLayout(QHBoxLayout):
     def __init__(
         self,
-        script: Script,
+        cfg: Config,
         field_cfg: str,
         label: str = None,
         placeholder: str = "",
@@ -26,7 +26,7 @@ class QLineEditLayout(QHBoxLayout):
         """
         super(QLineEditLayout, self).__init__(*args, **kwargs)
 
-        self.script = script
+        self.cfg = cfg
         self.field_cfg = field_cfg
 
         self.qedit = QLineEdit()
@@ -36,9 +36,9 @@ class QLineEditLayout(QHBoxLayout):
 
     def cfg_init(self):
         # NOTE: update timer -> cfg_init, setText seems to reset cursor position so we prevent it
-        val = self.script.cfg(self.field_cfg, str)
+        val = self.cfg(self.field_cfg, str)
         if self.qedit.text() != val:
             self.qedit.setText(val)
 
     def cfg_connect(self):
-        self.qedit.textChanged.connect(partial(self.script.cfg.set, self.field_cfg))
+        self.qedit.textChanged.connect(partial(self.cfg.set, self.field_cfg))

--- a/krita_plugin/krita_diff/widgets/line_edit.py
+++ b/krita_plugin/krita_diff/widgets/line_edit.py
@@ -19,7 +19,7 @@ class QLineEditLayout(QHBoxLayout):
         """Layout for labelled QLineEdit.
 
         Args:
-            script (Script): Script to connect to.
+            cfg (Config): Config to connect to.
             field_cfg (str): Config key to read/write value to.
             label (str, optional): Label, uses `field_cfg` if None. Defaults to None.
             placeholder (str, optional): Placeholder. Defaults to "".

--- a/krita_plugin/krita_diff/widgets/prompt.py
+++ b/krita_plugin/krita_diff/widgets/prompt.py
@@ -1,6 +1,6 @@
 from krita import QPlainTextEdit, QSizePolicy, QVBoxLayout
 
-from ..script import Script
+from ..config import Config
 from .misc import QLabel
 
 
@@ -21,7 +21,7 @@ class QPromptLayout(QVBoxLayout):
     neg_prompt_label: str = "Negative prompt:"
 
     def __init__(
-        self, script: Script, prompt_cfg: str, neg_prompt_cfg: str, *args, **kwargs
+        self, cfg: Config, prompt_cfg: str, neg_prompt_cfg: str, *args, **kwargs
     ):
         """Layout for prompt and negative prompt.
 
@@ -33,7 +33,7 @@ class QPromptLayout(QVBoxLayout):
         super(QPromptLayout, self).__init__(*args, **kwargs)
 
         # Used to connect to config stored in script
-        self.script = script
+        self.cfg = cfg
         self.prompt_cfg = prompt_cfg
         self.neg_prompt_cfg = neg_prompt_cfg
 
@@ -49,8 +49,8 @@ class QPromptLayout(QVBoxLayout):
 
     def cfg_init(self):
         # NOTE: update timer -> cfg_init, setText seems to reset cursor position so we prevent it
-        prompt = self.script.cfg(self.prompt_cfg, str)
-        neg_prompt = self.script.cfg(self.neg_prompt_cfg, str)
+        prompt = self.cfg(self.prompt_cfg, str)
+        neg_prompt = self.cfg(self.neg_prompt_cfg, str)
         if self.qedit_prompt.toPlainText() != prompt:
             self.qedit_prompt.setPlainText(prompt)
         if self.qedit_neg_prompt.toPlainText() != neg_prompt:
@@ -58,12 +58,10 @@ class QPromptLayout(QVBoxLayout):
 
     def cfg_connect(self):
         self.qedit_prompt.textChanged.connect(
-            lambda: self.script.cfg.set(
-                self.prompt_cfg, self.qedit_prompt.toPlainText()
-            )
+            lambda: self.cfg.set(self.prompt_cfg, self.qedit_prompt.toPlainText())
         )
         self.qedit_neg_prompt.textChanged.connect(
-            lambda: self.script.cfg.set(
+            lambda: self.cfg.set(
                 self.neg_prompt_cfg, self.qedit_neg_prompt.toPlainText()
             )
         )

--- a/krita_plugin/krita_diff/widgets/prompt.py
+++ b/krita_plugin/krita_diff/widgets/prompt.py
@@ -26,7 +26,7 @@ class QPromptLayout(QVBoxLayout):
         """Layout for prompt and negative prompt.
 
         Args:
-            script (Script): Script to connect to.
+            cfg (Config): Config to connect to.
             prompt_cfg (str): Config key to read/write prompt to.
             neg_prompt_cfg (str): Config key to read/write negative prompt to.
         """

--- a/krita_plugin/krita_diff/widgets/spin_box.py
+++ b/krita_plugin/krita_diff/widgets/spin_box.py
@@ -3,14 +3,14 @@ from typing import Union
 
 from krita import QDoubleSpinBox, QHBoxLayout, QSpinBox
 
-from ..script import Script
+from ..config import Config
 from .misc import QLabel
 
 
 class QSpinBoxLayout(QHBoxLayout):
     def __init__(
         self,
-        script: Script,
+        cfg: Config,
         field_cfg: str,
         label: str = None,
         min: Union[int, float] = 0.0,
@@ -33,7 +33,7 @@ class QSpinBoxLayout(QHBoxLayout):
         """
         super(QSpinBoxLayout, self).__init__(*args, **kwargs)
 
-        self.script = script
+        self.cfg = cfg
         self.field_cfg = field_cfg
 
         self.qlabel = QLabel(field_cfg if label is None else label)
@@ -53,7 +53,7 @@ class QSpinBoxLayout(QHBoxLayout):
         self.addWidget(self.qspin)
 
     def cfg_init(self):
-        self.qspin.setValue(self.script.cfg(self.field_cfg, self.cast))
+        self.qspin.setValue(self.cfg(self.field_cfg, self.cast))
 
     def cfg_connect(self):
-        self.qspin.valueChanged.connect(partial(self.script.cfg.set, self.field_cfg))
+        self.qspin.valueChanged.connect(partial(self.cfg.set, self.field_cfg))

--- a/krita_plugin/krita_diff/widgets/spin_box.py
+++ b/krita_plugin/krita_diff/widgets/spin_box.py
@@ -1,4 +1,5 @@
 from functools import partial
+from math import isclose
 from typing import Union
 
 from krita import QDoubleSpinBox, QHBoxLayout, QSpinBox
@@ -53,7 +54,11 @@ class QSpinBoxLayout(QHBoxLayout):
         self.addWidget(self.qspin)
 
     def cfg_init(self):
-        self.qspin.setValue(self.cfg(self.field_cfg, self.cast))
+        val = self.cfg(self.field_cfg, self.cast)
+        cur = self.qspin.value()
+        # prevent cursor from jumping when cfg_init is called by update
+        if not isclose(val, cur):
+            self.qspin.setValue(self.cfg(self.field_cfg, self.cast))
 
     def cfg_connect(self):
         self.qspin.valueChanged.connect(partial(self.cfg.set, self.field_cfg))

--- a/krita_plugin/krita_diff/widgets/spin_box.py
+++ b/krita_plugin/krita_diff/widgets/spin_box.py
@@ -24,7 +24,7 @@ class QSpinBoxLayout(QHBoxLayout):
         Will infer which to use based on type of min, max and step.
 
         Args:
-            script (Script): Script to connect to.
+            cfg (Config): Config to connect to.
             field_cfg (str): Config key to read/write value to.
             label (str, optional): Label, uses `field_cfg` if None. Defaults to None.
             min (Union[int, float], optional): Min value. Defaults to 0.0.

--- a/krita_server/app.py
+++ b/krita_server/app.py
@@ -135,8 +135,12 @@ async def f_txt2img(req: Txt2ImgRequest):
         *args,
     )
 
-    if not req.include_grid and len(output_images) > 1:
+    if not req.include_grid and len(output_images) > 1 and script_ind == 0:
         output_images = output_images[1:]
+
+    log.info(
+        f"Img Size: {output_images[0].width}x{output_images[0].height}, Resize Target: {req.orig_width}x{req.orig_height}"
+    )
 
     resized_images = [
         modules.images.resize_image(0, image, req.orig_width, req.orig_height)
@@ -198,6 +202,13 @@ async def f_img2img(req: Img2ImgRequest):
             req.base_size, req.max_size, orig_width, orig_height
         )
 
+    # SD scales by 2x image size
+    # NOTE: in krita we already scaled up, so have to downscale here
+    if script and script.title() == "SD upscale":
+        image = image.resize((image.width // 2, image.height // 2))
+        if mask:
+            mask = mask.resize((image.width // 2, image.height // 2))
+
     # NOTE:
     # - image & mask repeated due to Gradio API have separate tabs for each mode...
     # - mask is used only in inpaint mode
@@ -248,8 +259,12 @@ async def f_img2img(req: Img2ImgRequest):
         *args,
     )
 
-    if not req.include_grid and len(output_images) > 1:
+    if not req.include_grid and len(output_images) > 1 and script_ind == 0:
         output_images = output_images[1:]
+
+    log.info(
+        f"Img Size: {output_images[0].width}x{output_images[0].height}, Resize Target: {orig_width}x{orig_height}"
+    )
 
     resized_images = [
         modules.images.resize_image(0, image, orig_width, orig_height)

--- a/krita_server/config.py
+++ b/krita_server/config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 # NOTE: I changed some field names from krita_config.yaml to match the API endpoints
 
@@ -19,6 +19,8 @@ class GenerationOptions(BaseModel):
     """Model to use for generation."""
     script: str = "None"
     """Which script to use."""
+    script_args: list = Field(default_factory=list)
+    """List of args for script."""
 
     prompt: Any = "dog"
     """Requested prompt."""

--- a/krita_server/config.py
+++ b/krita_server/config.py
@@ -17,6 +17,8 @@ class BaseOptions(BaseModel):
 class GenerationOptions(BaseModel):
     sd_model: str = "model.ckpt"
     """Model to use for generation."""
+    script: str = "None"
+    """Which script to use."""
 
     prompt: Any = "dog"
     """Requested prompt."""

--- a/krita_server/script_hack.py
+++ b/krita_server/script_hack.py
@@ -3,11 +3,17 @@ Attempting to map Gradio UI elements present in scripts to allow
 converting to pyQt elements on the plugin side.
 """
 
+import logging
+from typing import List, Tuple
+
 import gradio as gr
 from webui import modules
 
+log = logging.getLogger(__name__)
+
 
 def inspect_ui(script: modules.scripts.Script, is_img2img: bool):
+    """Get metadata about accepted arguments by inspecting GUI."""
     with gr.Blocks():
         elems = script.ui(is_img2img)
 
@@ -70,6 +76,7 @@ txt2img_script_meta = None
 
 
 def get_scripts_metadata(is_img2img: bool):
+    """Get metadata about accepted arguments for scripts."""
     # NOTE: inspect_ui is quite slow, so cache this
     global txt2img_script_meta, img2img_script_meta
     if is_img2img:
@@ -93,3 +100,57 @@ def get_scripts_metadata(is_img2img: bool):
     else:
         txt2img_script_meta = metadata
     return metadata
+
+
+def get_script_info(
+    script_name: str, is_img2img: bool
+) -> Tuple[int, modules.scripts.Script, List[dict]]:
+    """Get index of script, script instance and argument metadata by name.
+
+    Args:
+        script_name (str): Exact name of script.
+        is_img2img (bool): Whether the script is for img2img or txt2img.
+
+    Raises:
+        KeyError: Script cannot be found.
+
+    Returns:
+        Tuple[int, Script, List[dict]]: Index of script, script itself and arguments metadata.
+    """
+    if is_img2img:
+        runner = modules.scripts.scripts_img2img
+    else:
+        runner = modules.scripts.scripts_txt2img
+    # in API, index 0 means no script, scripts are indexed from 1 onwards
+    names = ["None"] + runner.titles
+    if script_name == "None":
+        return 0, None, []
+    for i, n in enumerate(names):
+        if n == script_name:
+            script = runner.selectable_scripts[i - 1]
+            return i, script, get_scripts_metadata(is_img2img)[n]
+    raise KeyError(f"script not found for type {type}: {script_name}")
+
+
+def process_script_args(
+    script_ind: int, script: modules.scripts.Script, meta: List[dict], args: list
+) -> list:
+    """Get the position arguments required."""
+    if script is None:
+        return [0]  # 0th element selects which script to use. 0 is None.
+
+    # convert strings back to indexes
+    for i, (o, arg) in enumerate(zip(meta, args)):
+        if o["is_index"]:
+            if isinstance(arg, list):
+                args[i] = [o["opts"].index(v) for v in arg]
+            else:
+                args[i] = o["opts"].index(arg)
+
+    log.info(
+        f"Script selected: {script.filename}, Args Range: [{script.args_from}:{script.args_to}]"
+    )
+    # pad the args like the internal API requires...
+    args = [script_ind] + [0] * (script.args_from - 1) + args
+    log.info(f"Script args:\n{args}")
+    return args

--- a/krita_server/structs.py
+++ b/krita_server/structs.py
@@ -63,6 +63,10 @@ class ConfigResponse(PluginOptions):
     """List of available samplers."""
     samplers_img2img: List[str]
     """List of available samplers specifically for img2img (upstream separated them for a reason)."""
+    scripts_txt2img: List[str]
+    """List of available txt2img scripts."""
+    scripts_img2img: List[str]
+    """List of available img2img scripts."""
     face_restorers: List[str]
     """List of available face restorers."""
     sd_models: List[str]

--- a/krita_server/structs.py
+++ b/krita_server/structs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -63,9 +63,9 @@ class ConfigResponse(PluginOptions):
     """List of available samplers."""
     samplers_img2img: List[str]
     """List of available samplers specifically for img2img (upstream separated them for a reason)."""
-    scripts_txt2img: List[str]
+    scripts_txt2img: Dict[str, List[Dict]]
     """List of available txt2img scripts."""
-    scripts_img2img: List[str]
+    scripts_img2img: Dict[str, List[Dict]]
     """List of available img2img scripts."""
     face_restorers: List[str]
     """List of available face restorers."""

--- a/krita_server/ui_hack.py
+++ b/krita_server/ui_hack.py
@@ -13,7 +13,12 @@ def inspect_ui(script: modules.scripts.Script, is_img2img: bool):
 
     metadata = []
     for elem in elems:
-        data = {"type": "None", "label": elem.label, "val": elem.value}
+        data = {
+            "type": "None",
+            "label": elem.label,
+            "val": elem.value,
+            "is_index": False,
+        }
         if isinstance(elem, gr.HTML):
             data.update(val="")
         elif isinstance(elem, gr.Markdown):
@@ -28,11 +33,13 @@ def inspect_ui(script: modules.scripts.Script, is_img2img: bool):
         elif isinstance(elem, gr.Radio):
             data.update(
                 type="combo",
+                is_index=elem.type == "index",
                 opts=elem.choices,
             )
         elif isinstance(elem, gr.Dropdown):
             data.update(
                 type="combo",
+                is_index=elem.type == "index",
                 opts=elem.choices,
             )
         elif isinstance(elem, gr.Textbox):
@@ -46,6 +53,7 @@ def inspect_ui(script: modules.scripts.Script, is_img2img: bool):
         elif isinstance(elem, gr.CheckboxGroup):
             data.update(
                 type="multiselect",
+                is_index=elem.type == "index",
                 opts=elem.choices,
             )
         elif isinstance(elem, gr.File):

--- a/krita_server/ui_hack.py
+++ b/krita_server/ui_hack.py
@@ -15,9 +15,9 @@ def inspect_ui(script: modules.scripts.Script, is_img2img: bool):
     for elem in elems:
         data = {"type": "None", "label": elem.label, "val": elem.value}
         if isinstance(elem, gr.HTML):
-            pass
+            data.update(val="")
         elif isinstance(elem, gr.Markdown):
-            pass
+            data.update(val="")
         elif isinstance(elem, gr.Slider):
             data.update(
                 type="range",
@@ -49,9 +49,9 @@ def inspect_ui(script: modules.scripts.Script, is_img2img: bool):
                 opts=elem.choices,
             )
         elif isinstance(elem, gr.File):
-            pass  # unsupported
+            data.update(val="")  # unsupported
         else:
-            pass  # unsupported
+            data.update(val="")  # unsupported
         metadata.append(data)
 
     return metadata

--- a/krita_server/ui_hack.py
+++ b/krita_server/ui_hack.py
@@ -13,69 +13,46 @@ def inspect_ui(script: modules.scripts.Script, is_img2img: bool):
 
     metadata = []
     for elem in elems:
+        data = {"type": "None", "label": elem.label, "val": elem.value}
         if isinstance(elem, gr.HTML):
-            metadata.append({})
+            pass
         elif isinstance(elem, gr.Markdown):
-            metadata.append({})
+            pass
         elif isinstance(elem, gr.Slider):
-            metadata.append(
-                dict(
-                    type="range",
-                    label=elem.label,
-                    min=elem.minimum,
-                    max=elem.maximum,
-                    step=elem.step,
-                    val=elem.value,
-                )
+            data.update(
+                type="range",
+                min=elem.minimum,
+                max=elem.maximum,
+                step=elem.step,
             )
         elif isinstance(elem, gr.Radio):
-            metadata.append(
-                dict(
-                    type="combo",
-                    label=elem.label,
-                    opts=elem.choices,
-                    val=elem.value,
-                )
+            data.update(
+                type="combo",
+                opts=elem.choices,
             )
         elif isinstance(elem, gr.Dropdown):
-            metadata.append(
-                dict(
-                    type="combo",
-                    label=elem.label,
-                    opts=elem.choices,
-                    val=elem.value,
-                )
+            data.update(
+                type="combo",
+                opts=elem.choices,
             )
         elif isinstance(elem, gr.Textbox):
-            metadata.append(
-                dict(
-                    type="text",
-                    label=elem.label,
-                    val="",
-                )
+            data.update(
+                type="text",
             )
         elif isinstance(elem, gr.Checkbox):
-            metadata.append(
-                dict(
-                    type="checkbox",
-                    label=elem.label,
-                    val=elem.value,
-                )
+            data.update(
+                type="checkbox",
             )
         elif isinstance(elem, gr.CheckboxGroup):
-            metadata.append(
-                dict(
-                    type="multiselect",
-                    label=elem.label,
-                    val=elem.value,
-                )
+            data.update(
+                type="multiselect",
+                opts=elem.choices,
             )
         elif isinstance(elem, gr.File):
-            # unsupported
-            metadata.append({})
+            pass  # unsupported
         else:
-            # unsupported
-            metadata.append({})
+            pass  # unsupported
+        metadata.append(data)
 
     return metadata
 

--- a/krita_server/ui_hack.py
+++ b/krita_server/ui_hack.py
@@ -1,0 +1,110 @@
+"""
+Attempting to map Gradio UI elements present in scripts to allow
+converting to pyQt elements on the plugin side.
+"""
+
+import gradio as gr
+from webui import modules
+
+
+def inspect_ui(script: modules.scripts.Script, is_img2img: bool):
+    with gr.Blocks():
+        elems = script.ui(is_img2img)
+
+    metadata = []
+    for elem in elems:
+        if isinstance(elem, gr.HTML):
+            metadata.append({})
+        elif isinstance(elem, gr.Markdown):
+            metadata.append({})
+        elif isinstance(elem, gr.Slider):
+            metadata.append(
+                dict(
+                    type="range",
+                    label=elem.label,
+                    min=elem.minimum,
+                    max=elem.maximum,
+                    step=elem.step,
+                    val=elem.value,
+                )
+            )
+        elif isinstance(elem, gr.Radio):
+            metadata.append(
+                dict(
+                    type="combo",
+                    label=elem.label,
+                    opts=elem.choices,
+                    val=elem.value,
+                )
+            )
+        elif isinstance(elem, gr.Dropdown):
+            metadata.append(
+                dict(
+                    type="combo",
+                    label=elem.label,
+                    opts=elem.choices,
+                    val=elem.value,
+                )
+            )
+        elif isinstance(elem, gr.Textbox):
+            metadata.append(
+                dict(
+                    type="text",
+                    label=elem.label,
+                    val="",
+                )
+            )
+        elif isinstance(elem, gr.Checkbox):
+            metadata.append(
+                dict(
+                    type="checkbox",
+                    label=elem.label,
+                    val=elem.value,
+                )
+            )
+        elif isinstance(elem, gr.CheckboxGroup):
+            metadata.append(
+                dict(
+                    type="multiselect",
+                    label=elem.label,
+                    val=elem.value,
+                )
+            )
+        elif isinstance(elem, gr.File):
+            # unsupported
+            metadata.append({})
+        else:
+            # unsupported
+            metadata.append({})
+
+    return metadata
+
+
+img2img_script_meta = None
+txt2img_script_meta = None
+
+
+def get_scripts_metadata(is_img2img: bool):
+    # NOTE: inspect_ui is quite slow, so cache this
+    global txt2img_script_meta, img2img_script_meta
+    if is_img2img:
+        runner = modules.scripts.scripts_img2img
+    else:
+        runner = modules.scripts.scripts_txt2img
+    metadata = {"None": []}
+    if (
+        is_img2img
+        and img2img_script_meta
+        and len(img2img_script_meta) - 1 == len(runner.titles)
+    ):
+        return img2img_script_meta
+    elif txt2img_script_meta and len(txt2img_script_meta) - 1 == len(runner.titles):
+        return txt2img_script_meta
+
+    for name, script in zip(runner.titles, runner.selectable_scripts):
+        metadata[name] = inspect_ui(script, is_img2img)
+    if is_img2img:
+        img2img_script_meta = metadata
+    else:
+        txt2img_script_meta = metadata
+    return metadata

--- a/krita_server/utils.py
+++ b/krita_server/utils.py
@@ -4,10 +4,8 @@ import inspect
 import logging
 import os
 from base64 import b64decode, b64encode
-from enum import Enum
 from io import BytesIO
 from math import ceil
-from typing import Tuple
 
 import yaml
 from PIL import Image
@@ -287,36 +285,6 @@ def get_upscaler_index(upscaler_name: str):
         if upscaler.name == upscaler_name:
             return index
     raise KeyError(f"upscaler not found: {upscaler_name}")
-
-
-def get_script_info(
-    script_name: str, is_img2img: bool
-) -> Tuple[int, modules.scripts.Script]:
-    """Get index of script and script instance by name.
-
-    Args:
-        script_name (str): Exact name of script.
-        is_img2img (bool): Whether the script is for img2img or txt2img.
-
-    Raises:
-        KeyError: Script cannot be found.
-
-    Returns:
-        Tuple[int, Script]: Index of script and script itself.
-    """
-    if is_img2img:
-        runner = modules.scripts.scripts_img2img
-    else:
-        runner = modules.scripts.scripts_txt2img
-    # in API, index 0 means no script, scripts are indexed from 1 onwards
-    names = ["None"] + runner.titles
-    if script_name == "None":
-        return 0, None
-    for i, n in enumerate(names):
-        if n == script_name:
-            script = runner.selectable_scripts[i - 1]
-            return i, script
-    raise KeyError(f"script not found for type {type}: {script_name}")
 
 
 def prepare_mask(mask: Image.Image):

--- a/krita_server/utils.py
+++ b/krita_server/utils.py
@@ -289,37 +289,33 @@ def get_upscaler_index(upscaler_name: str):
     raise KeyError(f"upscaler not found: {upscaler_name}")
 
 
-class SCRIPT_TYPE(Enum):
-    TXT2IMG = 1
-    IMG2IMG = 2
-
-
-def get_script(
-    script_name: str, type: SCRIPT_TYPE
+def get_script_info(
+    script_name: str, is_img2img: bool
 ) -> Tuple[int, modules.scripts.Script]:
     """Get index of script and script instance by name.
 
     Args:
         script_name (str): Exact name of script.
-        type (SCRIPT_TYPE): Whether the script is for img2img or txt2img.
+        is_img2img (bool): Whether the script is for img2img or txt2img.
 
     Raises:
         KeyError: Script cannot be found.
 
     Returns:
-        Tuple[int, Script): Index of script and script itself.
+        Tuple[int, Script]: Index of script and script itself.
     """
-    if type == SCRIPT_TYPE.TXT2IMG:
-        runner = modules.scripts.scripts_txt2img
-    elif type == SCRIPT_TYPE.IMG2IMG:
+    if is_img2img:
         runner = modules.scripts.scripts_img2img
     else:
-        assert False
+        runner = modules.scripts.scripts_txt2img
     # in API, index 0 means no script, scripts are indexed from 1 onwards
     names = ["None"] + runner.titles
+    if script_name == "None":
+        return 0, None
     for i, n in enumerate(names):
         if n == script_name:
-            return i, runner.selectable_scripts[i - 1]
+            script = runner.selectable_scripts[i - 1]
+            return i, script
     raise KeyError(f"script not found for type {type}: {script_name}")
 
 

--- a/krita_server/utils.py
+++ b/krita_server/utils.py
@@ -4,8 +4,10 @@ import inspect
 import logging
 import os
 from base64 import b64decode, b64encode
+from enum import Enum
 from io import BytesIO
 from math import ceil
+from typing import Tuple
 
 import yaml
 from PIL import Image
@@ -285,6 +287,40 @@ def get_upscaler_index(upscaler_name: str):
         if upscaler.name == upscaler_name:
             return index
     raise KeyError(f"upscaler not found: {upscaler_name}")
+
+
+class SCRIPT_TYPE(Enum):
+    TXT2IMG = 1
+    IMG2IMG = 2
+
+
+def get_script(
+    script_name: str, type: SCRIPT_TYPE
+) -> Tuple[int, modules.scripts.Script]:
+    """Get index of script and script instance by name.
+
+    Args:
+        script_name (str): Exact name of script.
+        type (SCRIPT_TYPE): Whether the script is for img2img or txt2img.
+
+    Raises:
+        KeyError: Script cannot be found.
+
+    Returns:
+        Tuple[int, Script): Index of script and script itself.
+    """
+    if type == SCRIPT_TYPE.TXT2IMG:
+        runner = modules.scripts.scripts_txt2img
+    elif type == SCRIPT_TYPE.IMG2IMG:
+        runner = modules.scripts.scripts_img2img
+    else:
+        assert False
+    # in API, index 0 means no script, scripts are indexed from 1 onwards
+    names = ["None"] + runner.titles
+    for i, n in enumerate(names):
+        if n == script_name:
+            return i, runner.selectable_scripts[i - 1]
+    raise KeyError(f"script not found for type {type}: {script_name}")
 
 
 def prepare_mask(mask: Image.Image):


### PR DESCRIPTION
AUTOMATIC1111's script implementation doesn't expose any metadata about the parameters accepted by scripts. So I had to write a function to inspect the GUI generated by the script to extract that metadata myself.

Did you know it is surprisingly hard to create dynamic GUIs in pyQt? But I did it anyways.

And with that, all the scripts are exposed.

See tracking issue #39 for what has been tested to work so far.