### PR TITLE
Simple xor encryption support (manual activation required)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ opencv-python
 requests
 piexif
 Pillow
-pytorch_lightning
+pytorch_lightning==1.7.7
 realesrgan
 scikit-image>=0.19
 timm==0.4.12


### PR DESCRIPTION
Encrypted data:
1. Negative and Positive prompts (from Client to Server)
2. images - from Client to Server and on the Server before sending back to Client.

WebUI does work, when enable Encryption WebUI keep working.

Instruction for activation:
1. on Client (Krita plugin) - Open (in text editor) `krita_plugin/krita_diff/utils.py` in your plugin location, and edit (line 14-15):
`test_key = "test_encryption_key"` - set *your_text_key* (any text key)
`use_encryption = False` - set to True
2. on Server - create file `xor_pass.txt` with *your_text_key* - same as in plugin above (at krita_config.yaml file location, top level)
on Colab - `echo "your_text_key" > xor_pass.txt`

As result youl see on Server in terminal-output: (instead text prompts)
![image](https://user-images.githubusercontent.com/24825887/199760551-b48b0b19-4634-4867-ad90-1f88824f63ef.png)
